### PR TITLE
replace contextlib2 with contextlib

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 arrow==0.17.0
 attrs==20.3.0
-contextlib2==0.6.0.post1
 dotmap==1.3.23
 inform==1.23.0
 iniconfig==1.1.1

--- a/parametrize_from_file/schema.py
+++ b/parametrize_from_file/schema.py
@@ -2,7 +2,7 @@ import pytest, re
 from .errors import ConfigError
 from unittest.mock import MagicMock
 from more_itertools import always_iterable
-from contextlib2 import nullcontext
+from contextlib import nullcontext
 
 def cast(**funcs):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
   'tidyexc',
   'pytest',
   'more_itertools~=8.10',
-  'contextlib2',
   'decopatch',
 ]
 classifiers = [


### PR DESCRIPTION
`contextlib.nullcontext` was added in Python 3.7 which is the oldest supported version